### PR TITLE
Clean up client routing

### DIFF
--- a/client/elm.json
+++ b/client/elm.json
@@ -8,6 +8,7 @@
         "direct": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.1",
             "avh4/elm-color": "1.0.0",
+            "edkv/elm-generic-dict": "1.0.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/file": "1.0.5",

--- a/client/index.html
+++ b/client/index.html
@@ -1,29 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-	<meta charset="UTF-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Golden Gateway - Home</title>
-	<style>
-		body {
-			padding: 0;
-			margin: 0;
-		}
-	</style>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content=
+  "width=device-width, initial-scale=1.0">
+  <title>Golden Gateway - Home</title>
+  <style>
+                body {
+                        padding: 0;
+                        margin: 0;
+                }
+  </style>
 </head>
-
 <body>
-
-	<pre id="elm"></pre>
-
-	<script type="module" src="index.js"></script>
-	<script>
-		var app = Elm.HomePage.init({
-			node: document.getElementById("elm")
-		});
-	</script>
+  <pre id="elm"></pre>
+  <script type="module" src="index.js"></script>
 </body>
-
 </html>

--- a/client/src/Main.elm
+++ b/client/src/Main.elm
@@ -54,16 +54,7 @@ import TypedSvg.Attributes exposing (dy, stroke, textAnchor, transform, viewBox,
 import TypedSvg.Core exposing (Svg)
 import TypedSvg.Types exposing (AnchorAlignment(..), Paint(..), Transform(..), em)
 import UINotification as Notify
-import Url exposing (Protocol(..), Url)
-
-
-type DisplayPage
-    = LoginPage
-    | Catalogue
-    | ConstructLevel1
-    | AddLevel0Page
-    | AddBackbonePage
-    | AdminApp
+import Url exposing (Url)
 
 
 

--- a/client/src/Main.elm
+++ b/client/src/Main.elm
@@ -95,8 +95,8 @@ gotoRoute model page =
             Router.changeRoute rtr model.auth page
 
 
-viewRoute : Model -> Element Msg
-viewRoute model =
+viewPage : Model -> Element Msg
+viewPage model =
     case model.router of
         Router rtr ->
             Router.viewRoute rtr model
@@ -223,7 +223,7 @@ view model =
                     , Element.height Element.fill
                     , Element.scrollbarY
                     ]
-                    (viewRoute model)
+                    (viewPage model)
                 ]
             )
         ]

--- a/client/src/Main.elm
+++ b/client/src/Main.elm
@@ -7,7 +7,6 @@ import Auth
     exposing
         ( Auth(..)
         , Login
-        , authCode
         , authDecoder
         )
 import Browser exposing (Document)
@@ -44,16 +43,18 @@ import List
 import List.Extra
 import Molecules exposing (..)
 import Path
+import Router
 import Shape exposing (defaultPieConfig)
 import Storage
 import String
 import Task
+import Tuple
 import TypedSvg exposing (g, svg, text_)
 import TypedSvg.Attributes exposing (dy, stroke, textAnchor, transform, viewBox, x)
 import TypedSvg.Core exposing (Svg)
 import TypedSvg.Types exposing (AnchorAlignment(..), Paint(..), Transform(..), em)
 import UINotification as Notify
-import Url exposing (Url)
+import Url exposing (Protocol(..), Url)
 
 
 type DisplayPage
@@ -62,6 +63,7 @@ type DisplayPage
     | ConstructLevel1
     | AddLevel0Page
     | AddBackbonePage
+    | AdminApp
 
 
 
@@ -69,7 +71,7 @@ type DisplayPage
 
 
 type alias Model =
-    { page : DisplayPage
+    { router : Router
     , api : Api Msg
     , filterOverhang : Bsa1Overhang -- Used for filtering the overhangs depending on the application
     , currLevel1App : Application -- Used for filtering the tables on overhang
@@ -91,21 +93,37 @@ type alias Model =
     }
 
 
+type Router
+    = Router (Router.Router Model Msg)
+
+
+gotoRoute : { a | auth : Auth, router : Router } -> Router.Page -> Cmd Msg
+gotoRoute model page =
+    case model.router of
+        Router rtr ->
+            Router.changeRoute rtr model.auth page
+
+
+viewRoute : Model -> Element Msg
+viewRoute model =
+    case model.router of
+        Router rtr ->
+            Router.viewRoute rtr model
+
+
+changePage : Router -> Url -> Router
+changePage router url =
+    case router of
+        Router rtr ->
+            Router (Router.changePage rtr url)
+
+
 init : Decode.Value -> Url -> Nav.Key -> ( Model, Cmd Msg )
 init flags url key =
     let
         auth : Auth
         auth =
             Storage.fromJson flags
-
-        page : DisplayPage
-        page =
-            case auth of
-                Authenticated _ ->
-                    Catalogue
-
-                _ ->
-                    LoginPage
 
         api : Result String (Api Msg)
         api =
@@ -126,9 +144,18 @@ init flags url key =
                 _ ->
                     Notify.init
 
+        router : Router.Router Model Msg
+        router =
+            Router.mkRouter key (Result.withDefault dummyApi api) auth
+                |> Router.withPageView "/login" Router.Login loginView
+                |> Router.withPageView "/" Router.Catalogue catalogueView
+                |> Router.withPageView "/new/level0" Router.AddLevel0 addLevel0View
+                |> Router.withPageView "/new/level1" Router.AddLevel1 constructLevel1View
+                |> Router.withPageView "/new/backbone" Router.AddBackbone addBackboneView
+
         model : Model
         model =
-            { page = page
+            { router = Router router
             , api = Result.withDefault dummyApi api
             , currLevel1App = Standard
             , filterOverhang = A__B
@@ -147,7 +174,7 @@ init flags url key =
             , vectorToAdd = Nothing
             }
     in
-    ( model, router url model )
+    ( model, router.goto auth url )
 
 
 type Msg
@@ -156,8 +183,8 @@ type Msg
     | Logout
     | UrlChanged Url
     | LinkClicked Browser.UrlRequest
-      -- Msg Switching pages
-    | SwitchPage DisplayPage
+      -- Change client side route
+    | ChangeRoute Router.Page
       -- Vector catalogue Msg
     | BackboneAccordionToggled -- TODO: Unify these 3
     | Level0AccordionToggled
@@ -205,37 +232,7 @@ view model =
                     , Element.height Element.fill
                     , Element.scrollbarY
                     ]
-                    (case model.page of
-                        LoginPage ->
-                            loginView model
-
-                        Catalogue ->
-                            catalogueView model
-
-                        ConstructLevel1 ->
-                            case model.vectorToAdd of
-                                Just (LevelNVec vec) ->
-                                    constructLevel1View model vec
-
-                                _ ->
-                                    constructLevel1View model initLevel1
-
-                        AddLevel0Page ->
-                            case model.vectorToAdd of
-                                Just (Level0Vec vec) ->
-                                    addLevel0View vec
-
-                                _ ->
-                                    addLevel0View initLevel0
-
-                        AddBackbonePage ->
-                            case model.vectorToAdd of
-                                Just (BackboneVec vec) ->
-                                    addBackboneView vec
-
-                                _ ->
-                                    addBackboneView initBackbone
-                    )
+                    (viewRoute model)
                 ]
             )
         ]
@@ -275,7 +272,7 @@ catalogueView model =
                 , backboneTable model
                 , Element.row
                     [ centerX, spacing 50 ]
-                    [ addButton (SwitchPage AddBackbonePage) ]
+                    [ addButton (ChangeRoute Router.AddBackbone) ]
                 ]
             )
             model.backboneAccordionStatus
@@ -299,7 +296,7 @@ catalogueView model =
                     }
                 , overhangRadioRow model
                 , level0Table model
-                , Element.row [ centerX, spacing 50 ] [ addButton (SwitchPage AddLevel0Page) ]
+                , Element.row [ centerX, spacing 50 ] [ addButton (ChangeRoute Router.AddLevel0) ]
                 ]
             )
             model.level0AccordionStatus
@@ -327,8 +324,18 @@ catalogueView model =
         ]
 
 
-addLevel0View : Level0 -> Element Msg
-addLevel0View level0 =
+addLevel0View : Model -> Element Msg
+addLevel0View model =
+    let
+        level0 : Level0
+        level0 =
+            case model.vectorToAdd of
+                Just (Level0Vec vec) ->
+                    vec
+
+                _ ->
+                    initLevel0
+    in
     column [ Element.height Element.fill, padding 25, spacing 25 ]
         [ el [ Element.Region.heading 1, Font.size 50 ] <| Element.text "Add new Level 0 donor vector"
         , Input.text []
@@ -437,8 +444,18 @@ makeBsmb1OverhangOptions overHangList =
     List.map (\ohang -> Input.option ohang (showBsmb1Overhang ohang |> Element.text)) overHangList
 
 
-addBackboneView : Backbone -> Element Msg
-addBackboneView bb =
+addBackboneView : Model -> Element Msg
+addBackboneView model =
+    let
+        bb : Backbone
+        bb =
+            case model.vectorToAdd of
+                Just (BackboneVec vec) ->
+                    vec
+
+                _ ->
+                    initBackbone
+    in
     column [ Element.height Element.fill, centerX, Element.width Element.fill, spacing 25, padding 25 ]
         [ el [ Element.Region.heading 1, Font.size 50 ] <| Element.text "Add new Backbone"
         , Input.text []
@@ -583,8 +600,18 @@ addBackboneView bb =
         ]
 
 
-constructLevel1View : Model -> Level1 -> Element Msg
-constructLevel1View model level1 =
+constructLevel1View : Model -> Element Msg
+constructLevel1View model =
+    let
+        level1 : Level1
+        level1 =
+            case model.vectorToAdd of
+                Just (LevelNVec vec) ->
+                    vec
+
+                _ ->
+                    initLevel1
+    in
     column [ Element.height Element.fill, spacing 25, Element.width Element.fill, centerX, padding 50 ]
         [ el
             [ Element.Region.heading 1
@@ -866,12 +893,19 @@ navLinks auth =
     case auth of
         Authenticated user ->
             navBar
-                [ buttonLink_ (Just (SwitchPage Catalogue)) "Home"
-                , buttonLink_ (Just (SwitchPage Catalogue)) "Vector Catalogue"
-                , buttonLink_ (Just (SwitchPage ConstructLevel1)) "New Level1 construct"
-                , buttonLink_ Nothing <| Maybe.withDefault "Unknown name" user.name
-                , buttonLink_ (Just Logout) "Logout"
-                ]
+                ([ buttonLink_ (Just (ChangeRoute Router.Catalogue)) "Home"
+                 , buttonLink_ (Just (ChangeRoute Router.Catalogue)) "Vector Catalogue"
+                 , buttonLink_ (Just (ChangeRoute Router.AddLevel1)) "New Level1 construct"
+                 , buttonLink_ Nothing <| Maybe.withDefault "Unknown name" user.name
+                 , buttonLink_ (Just Logout) "Logout"
+                 ]
+                    ++ (if user.role == "admin" then
+                            [ buttonLink_ (Just (ChangeRoute Router.Admin)) "Admin" ]
+
+                        else
+                            []
+                       )
+                )
 
         _ ->
             navBar
@@ -900,8 +934,8 @@ overhangRadioRow model =
 
         theOverhangShape : List Bsa1Overhang
         theOverhangShape =
-            case model.page of
-                ConstructLevel1 ->
+            case model.vectorToAdd of
+                Just (LevelNVec _) ->
                     overhangShape model.currLevel1App
 
                 _ ->
@@ -1240,7 +1274,10 @@ update msg model =
             ( { model | filterOverhang = newCurrOverhang }, Cmd.none )
 
         UrlChanged url ->
-            ( model, router url model )
+            ( { model | router = changePage model.router url }, Cmd.none )
+
+        ChangeRoute page ->
+            ( model, gotoRoute model page )
 
         GotLoginUrls res ->
             case res of
@@ -1263,31 +1300,35 @@ update msg model =
                     ( model, Nav.load href )
 
         GotAuthentication res ->
-            let
-                navToRoot : Cmd Msg
-                navToRoot =
-                    Nav.pushUrl model.key "/"
-            in
             case res of
                 Ok auth ->
-                    ( { model | auth = auth, page = Catalogue }
-                    , Cmd.batch [ navToRoot, model.api.vectors auth, Storage.toJson auth |> Storage.save ]
+                    let
+                        gotoRoot =
+                            gotoRoute { auth = auth, router = model.router } Router.Catalogue
+                    in
+                    ( { model | auth = auth }
+                    , Cmd.batch
+                        [ gotoRoot
+                        , model.api.vectors auth
+                        , Storage.toJson auth |> Storage.save
+                        ]
                     )
 
                 Err err ->
                     ( { model
                         | notifications = Notify.makeError "Logging in" (showHttpError err) model.notifications
                       }
-                    , navToRoot
+                    , gotoRoute model Router.Login
                     )
 
         Logout ->
-            ( { model | auth = Auth.init, page = LoginPage }
-            , Cmd.batch [ Nav.pushUrl model.key "/login", Storage.toJson Auth.init |> Storage.save ]
+            let
+                gotoLogin =
+                    gotoRoute { auth = Auth.init, router = model.router } Router.Login
+            in
+            ( { model | auth = Auth.init }
+            , Cmd.batch [ gotoLogin, Storage.toJson Auth.init |> Storage.save ]
             )
-
-        SwitchPage page ->
-            ( { model | page = page }, Cmd.none )
 
         FilterBackboneTable filter ->
             ( { model | backboneFilterString = Just filter }, Cmd.none )
@@ -1371,9 +1412,8 @@ update msg model =
         VectorCreated (Ok vec) ->
             ( { model
                 | vectors = vec :: model.vectors
-                , page = Catalogue
               }
-            , Cmd.none
+            , gotoRoute model Router.Catalogue
             )
 
         AddLevel1 level1 ->
@@ -1434,31 +1474,6 @@ appendInsertToLevel1 l0List newL0 =
                     l0.bsa1Overhang /= newL0.bsa1Overhang
                 )
                 l0List
-
-
-
--- ROUTING
-
-
-router : Url -> { a | auth : Auth, key : Nav.Key, api : Api Msg } -> Cmd Msg
-router url model =
-    case ( url.path, model.auth ) of
-        ( "/oidc_login", _ ) ->
-            authCode url
-                |> Maybe.map model.api.authorize
-                |> Maybe.withDefault Cmd.none
-
-        ( "/login", NotAuthenticated _ ) ->
-            model.api.login
-
-        ( "/login", _ ) ->
-            Nav.pushUrl model.key "/"
-
-        ( _, NotAuthenticated _ ) ->
-            Nav.pushUrl model.key "login"
-
-        _ ->
-            Cmd.none
 
 
 

--- a/client/src/Main.elm
+++ b/client/src/Main.elm
@@ -175,7 +175,7 @@ type Msg
     | UrlChanged Url
     | LinkClicked Browser.UrlRequest
       -- Change client side route
-    | ChangePage Router.Page
+    | SwitchPage Router.Page
       -- Vector catalogue Msg
     | BackboneAccordionToggled -- TODO: Unify these 3
     | Level0AccordionToggled
@@ -263,7 +263,7 @@ catalogueView model =
                 , backboneTable model
                 , Element.row
                     [ centerX, spacing 50 ]
-                    [ addButton (ChangePage Router.AddBackbone) ]
+                    [ addButton (SwitchPage Router.AddBackbone) ]
                 ]
             )
             model.backboneAccordionStatus
@@ -287,7 +287,7 @@ catalogueView model =
                     }
                 , overhangRadioRow model
                 , level0Table model
-                , Element.row [ centerX, spacing 50 ] [ addButton (ChangePage Router.AddLevel0) ]
+                , Element.row [ centerX, spacing 50 ] [ addButton (SwitchPage Router.AddLevel0) ]
                 ]
             )
             model.level0AccordionStatus
@@ -884,14 +884,14 @@ navLinks auth =
     case auth of
         Authenticated user ->
             navBar
-                ([ buttonLink_ (Just (ChangePage Router.Catalogue)) "Home"
-                 , buttonLink_ (Just (ChangePage Router.Catalogue)) "Vector Catalogue"
-                 , buttonLink_ (Just (ChangePage Router.AddLevel1)) "New Level1 construct"
+                ([ buttonLink_ (Just (SwitchPage Router.Catalogue)) "Home"
+                 , buttonLink_ (Just (SwitchPage Router.Catalogue)) "Vector Catalogue"
+                 , buttonLink_ (Just (SwitchPage Router.AddLevel1)) "New Level1 construct"
                  , buttonLink_ Nothing <| Maybe.withDefault "Unknown name" user.name
                  , buttonLink_ (Just Logout) "Logout"
                  ]
                     ++ (if user.role == "admin" then
-                            [ buttonLink_ (Just (ChangePage Router.Admin)) "Admin" ]
+                            [ buttonLink_ (Just (SwitchPage Router.Admin)) "Admin" ]
 
                         else
                             []
@@ -1267,7 +1267,7 @@ update msg model =
         UrlChanged url ->
             ( { model | router = changePage model.router url }, Cmd.none )
 
-        ChangePage page ->
+        SwitchPage page ->
             ( model, gotoRoute model page )
 
         GotLoginUrls res ->

--- a/client/src/Main.elm
+++ b/client/src/Main.elm
@@ -184,7 +184,7 @@ type Msg
     | UrlChanged Url
     | LinkClicked Browser.UrlRequest
       -- Change client side route
-    | ChangeRoute Router.Page
+    | ChangePage Router.Page
       -- Vector catalogue Msg
     | BackboneAccordionToggled -- TODO: Unify these 3
     | Level0AccordionToggled
@@ -272,7 +272,7 @@ catalogueView model =
                 , backboneTable model
                 , Element.row
                     [ centerX, spacing 50 ]
-                    [ addButton (ChangeRoute Router.AddBackbone) ]
+                    [ addButton (ChangePage Router.AddBackbone) ]
                 ]
             )
             model.backboneAccordionStatus
@@ -296,7 +296,7 @@ catalogueView model =
                     }
                 , overhangRadioRow model
                 , level0Table model
-                , Element.row [ centerX, spacing 50 ] [ addButton (ChangeRoute Router.AddLevel0) ]
+                , Element.row [ centerX, spacing 50 ] [ addButton (ChangePage Router.AddLevel0) ]
                 ]
             )
             model.level0AccordionStatus
@@ -893,14 +893,14 @@ navLinks auth =
     case auth of
         Authenticated user ->
             navBar
-                ([ buttonLink_ (Just (ChangeRoute Router.Catalogue)) "Home"
-                 , buttonLink_ (Just (ChangeRoute Router.Catalogue)) "Vector Catalogue"
-                 , buttonLink_ (Just (ChangeRoute Router.AddLevel1)) "New Level1 construct"
+                ([ buttonLink_ (Just (ChangePage Router.Catalogue)) "Home"
+                 , buttonLink_ (Just (ChangePage Router.Catalogue)) "Vector Catalogue"
+                 , buttonLink_ (Just (ChangePage Router.AddLevel1)) "New Level1 construct"
                  , buttonLink_ Nothing <| Maybe.withDefault "Unknown name" user.name
                  , buttonLink_ (Just Logout) "Logout"
                  ]
                     ++ (if user.role == "admin" then
-                            [ buttonLink_ (Just (ChangeRoute Router.Admin)) "Admin" ]
+                            [ buttonLink_ (Just (ChangePage Router.Admin)) "Admin" ]
 
                         else
                             []
@@ -1276,7 +1276,7 @@ update msg model =
         UrlChanged url ->
             ( { model | router = changePage model.router url }, Cmd.none )
 
-        ChangeRoute page ->
+        ChangePage page ->
             ( model, gotoRoute model page )
 
         GotLoginUrls res ->

--- a/client/src/Router.elm
+++ b/client/src/Router.elm
@@ -128,10 +128,6 @@ withPageView url page view router =
 
 mkGoto : Nav.Key -> Api msg -> Auth -> Url -> Cmd msg
 mkGoto key api auth url =
-    let
-        _ =
-            Debug.log "goto" url.path
-    in
     case ( url.path, auth ) of
         ( "/oidc_login", _ ) ->
             authCode url
@@ -148,10 +144,6 @@ mkGoto key api auth url =
                 ]
 
         ( _, Authenticated _ ) ->
-            let
-                _ =
-                    Debug.log "url" url.path
-            in
             Nav.pushUrl key url.path
 
 

--- a/client/src/Router.elm
+++ b/client/src/Router.elm
@@ -1,0 +1,192 @@
+module Router exposing
+    ( Page(..)
+    , Router
+    , changePage
+    , changeRoute
+    , mkRouter
+    , viewRoute
+    , withPageView
+    )
+
+{-| Handling of client side routing
+-}
+
+import Api exposing (Api)
+import Auth exposing (Auth(..), authCode)
+import Browser.Navigation as Nav
+import Element exposing (Element, text)
+import GenericDict as Dict exposing (Dict)
+import Url exposing (Protocol(..), Url)
+
+
+{-| The available pages within the app
+-}
+type Page
+    = Login
+    | Catalogue
+    | AddLevel1
+    | AddLevel0
+    | AddBackbone
+    | Admin
+
+
+{-| Make the custom Page type a comparable
+-}
+pageToString : Page -> String
+pageToString page =
+    case page of
+        Login ->
+            "login"
+
+        Catalogue ->
+            "catalogue"
+
+        AddLevel1 ->
+            "new/level1"
+
+        AddLevel0 ->
+            "new/level0"
+
+        AddBackbone ->
+            "new/backbone"
+
+        Admin ->
+            "admin"
+
+
+{-| Mapping of Url to Page
+-}
+urlToPage : Url -> Maybe Page
+urlToPage url =
+    case url.path of
+        "/login" ->
+            Just Login
+
+        "/" ->
+            Just Catalogue
+
+        "/admin" ->
+            Just Admin
+
+        "/new/level0" ->
+            Just AddLevel0
+
+        "/new/level1" ->
+            Just AddLevel1
+
+        _ ->
+            Nothing
+
+
+type alias Router model msg =
+    { page : Page
+    , goto : Auth -> Url -> Cmd msg
+    , view : Dict Page (model -> Element msg)
+    , routes : Dict Page Url
+    }
+
+
+{-| Builder initialisation function for a Router
+This should be followed by one-or-more calls to
+withPageView to define client-side routes.
+-}
+mkRouter : Nav.Key -> Api msg -> Auth -> Router model msg
+mkRouter key api auth =
+    { page =
+        case auth of
+            Authenticated _ ->
+                Catalogue
+
+            _ ->
+                Login
+    , goto = mkGoto key api
+    , view = Dict.empty
+    , routes = Dict.empty
+    }
+
+
+{-| Define client-side routes.
+-}
+withPageView : String -> Page -> (model -> Element msg) -> Router model msg -> Router model msg
+withPageView url page view router =
+    let
+        url_ : Url
+        url_ =
+            { protocol = Http
+            , host = ""
+            , port_ = Nothing
+            , path = url
+            , query = Nothing
+            , fragment = Nothing
+            }
+    in
+    { router
+        | view = Dict.insert pageToString page view router.view
+        , routes = Dict.insert pageToString page url_ router.routes
+    }
+
+
+mkGoto : Nav.Key -> Api msg -> Auth -> Url -> Cmd msg
+mkGoto key api auth url =
+    let
+        _ =
+            Debug.log "goto" url.path
+    in
+    case ( url.path, auth ) of
+        ( "/oidc_login", _ ) ->
+            authCode url
+                |> Maybe.map api.authorize
+                |> Maybe.withDefault Cmd.none
+
+        ( "/login", Authenticated _ ) ->
+            Nav.pushUrl key "/"
+
+        ( _, NotAuthenticated _ ) ->
+            Cmd.batch
+                [ Nav.pushUrl key "login"
+                , api.login
+                ]
+
+        ( _, Authenticated _ ) ->
+            let
+                _ =
+                    Debug.log "url" url.path
+            in
+            Nav.pushUrl key url.path
+
+
+{-| Navigate to the URL for a given page
+-}
+changeRoute : Router model msg -> Auth -> Page -> Cmd msg
+changeRoute router auth page =
+    Dict.get pageToString page router.routes
+        |> Maybe.map (router.goto auth)
+        |> Maybe.withDefault Cmd.none
+
+
+{-| Update the Router when a Url change occurs
+-}
+changePage : Router model msg -> Url -> Router model msg
+changePage router url =
+    let
+        page : Maybe Page
+        page =
+            urlToPage url
+    in
+    { router | page = Maybe.withDefault Catalogue page }
+
+
+{-| Run the view function for the current page
+-}
+viewRoute : Router model msg -> model -> Element msg
+viewRoute router m =
+    Dict.get pageToString router.page router.view
+        |> Maybe.map ((|>) m)
+        |> Maybe.withDefault invalidRouteView
+
+
+{-| The 404 view
+-}
+invalidRouteView : Element msg
+invalidRouteView =
+    text "Not a valid route"


### PR DESCRIPTION
- Introduce a custom Router type to track routing based on a Page
- Introduce a custom Page type to label specific routes
- Use client side-routing facilities provided by the Elm runtime

This change is in preparation for an administrative interface 